### PR TITLE
 Battery::getPercentage(): fixed issue that shows 100% instead of 0%

### DIFF
--- a/src/utility/battery.cpp
+++ b/src/utility/battery.cpp
@@ -30,13 +30,18 @@ double Battery::getVoltage() {
 }
 
 int Battery::getPercentage() {
-
-	int res = 101 - (101 / pow(1 + pow(1.33 * ((int)(getVoltage() * 100) - BATTERY_VMIN)/(BATTERY_VMAX - BATTERY_VMIN), 4.5), 3));
-
-	if(res >= 100)
-		res = 100;
-
-	return res;
+    int voltage_by_100 = (int)(getVoltage() * 100);
+    
+    if(voltage_by_100 > BATTERY_VMAX) {
+        return 100;
+    } else if(voltage_by_100 < BATTERY_VMIN) {
+        return 0;
+    } else {
+        int res = 101 - (101 / pow(1 + pow(1.33 * (voltage_by_100 - BATTERY_VMIN)/(BATTERY_VMAX - BATTERY_VMIN), 4.5), 3));
+        if(res > 100)
+            res = 100;
+        return res;
+    }
 }
 
 void Battery::setProtection(bool enable) {


### PR DESCRIPTION
I noticed that getPercentage() reported 100% for voltages below 3.3V (BATTERY_VMIN) - on my device. That is far from sensible.
As i see no check against this (and BATTERY_CUTOFF is even below BATTERY_VMIN, which is a bit odd), i just modified it the way it seems plausible to me (who does not know anything about the physics/maths involved!). 
Maybe the "if(res > 100)" became redundant, but as i do not understand the calculation, i did not dare to to remove that myself.
Oh, and: I *assume* BATTERY_VMIN should map to 0% (i did not "see" that in the calculation, too).
Please note: i did not really test this - as it would take some time and i do not see a (simple) way to get the percentage calculated for a certain voltage reading (and even immediately repated readings tend to differ).