### PR TITLE
Remove duplicated serial port initialization in Tetris

### DIFF
--- a/examples/Applications/Tetris/Tetris.ino
+++ b/examples/Applications/Tetris/Tetris.ino
@@ -39,7 +39,6 @@ Block blocks[7] = {
 extern uint8_t tetris_img[];
 //========================================================================
 void setup(void) {
-  Serial.begin(115200);         // SERIAL
   GO.begin();                   // M5STACK INITIALIZE
   GO.lcd.setBrightness(200);    // BRIGHTNESS = MAX 255
   GO.lcd.fillScreen(BLACK);     // CLEAR SCREEN


### PR DESCRIPTION
The duplicated serial port initialization in the Tetris source code is removed
such that Tetris starts successfully on a current ODROID GO model.

See https://forum.odroid.com/viewtopic.php?p=309579#p309579